### PR TITLE
update docs to reflect archival feature

### DIFF
--- a/docs/case-study.md
+++ b/docs/case-study.md
@@ -699,7 +699,7 @@ Edamame configures a default custom-dashboard for users that features these addi
 
 ## Future plans
 
-Edamame provides a robust framework for performing distributed load tests that target both HTTP and WebSockets. It supports tests of up to 200k virtual users, sufficiently tests complex systems with multiple protocols, and uses a performant data pipeline to aggregate and visualize data in near real-time. That being said, there are several improvements and additional features that could be added in the future.
+Edamame provides a robust framework for performing distributed load tests that target both HTTP and WebSockets. It supports tests of up to 200k virtual users, sufficiently tests complex systems with multiple protocols, and uses a performant data pipeline to aggregate and visualize data in near real-time. That being said, there are improvements and additional features that could be added in the future.
 
 ### Improving scalability
 
@@ -728,14 +728,6 @@ That being said, aggregating data at each load generator involves sharing comput
 Edamame specifies a default of 20k virtual users per load generator, but also provides the ability to set a custom number for this value. This leads to the following question: how does the user understand whether or not they are overloading load generator hosts? To provide users with better insight into load test performance, Edamame can increase observability. Currently, visibility into the health of load generators can be ascertained by installing a Kubernetes Dashboard.[^32]
 
 Rather than relying on additional third-party resources, in the future Edamame should provide metrics like CPU consumption, RAM consumption, and bandwidth for load generators. This would allow the user to tailor how load generating infrastructure is set up in a way that's more specific to the tests they are running.
-
-### Data import and export
-
-Edamame provides users with an `edamame teardown` command which deletes all associated AWS resources, including historical data. This means that data is not persisted beyond the lifecycle of the EKS cluster that supports Edamame’s architecture. We'd like to give users a way to export data when removing AWS resources, to decrease vendor lock-in.
-
-As Edamame contains a separate backend API for the database in the form of an Express app, components are already in place to provide this service. To perform the export, one approach would be to create an SQL file representing all the data in the database, which could be downloaded to the user's local system. This file could then be used to load the data into another database of the user's choosing.
-
-This approach would also enable Edamame to check for the presence of such a file during the initialization process, and use it to populate the database with the previous cluster's data. This would ensure that data is persisted across cluster lifecycles, should the user ever need to take down their EKS infrastructure for any reason.
 
 ## Resources
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -215,6 +215,14 @@ Terminal Output:
 [05:53:20:548] ✔ Deleted the test named: '40k VUs'...
 ```
 
+### edamame archive
+
+If a user wants or needs to temporarily teardown their Edamame cluster, they can persist all their historical load test data beyond the life of their AWS EKS Cluster by executing `edamame archive --all`. This command uploads data associated with each individual test as compressed file objects with the storage class Standard Infrequent Access into an AWS S3 Bucket. If a user wants to archive only the data associated with one historical test, then they can execute `edamame archive --name testName` and replace testName with the name of the test that they would like to archive. The files are archived as objects with Standard Infrequent Access, because this tier provides quick retrieval access and cheap storage relative to some of the other AWS storage class categories. Edamame currently doesn't offer the flexibility to change the storage class of these file uploads via the CLI. However, if a user plans to have this archived data in cold storage for a long time and wants a cheaper storage class option, then they can use Amazon S3 Lifecycle to update the storage class to one of the Glacier categories.
+
+### edamame delete-from-archive
+
+If a user decides they no longer need the data associated with all or one of their historical load tests that currently exists as an object in their AWS S3 Bucket, then they can execute `edamame delete-from-archive --all` or `edamame delete-from-archive --name testName` to delete all the load test data stored in AWS S3 or the data associated with one historical load test.
+
 ### edamame teardown
 
 If a user no longer wants or needs to run load tests and has no desire to retain any existing load test data, they can delete all existing load test data and AWS infrastructure by executing the command `edamame teardown`.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -219,9 +219,33 @@ Terminal Output:
 
 If a user wants or needs to temporarily teardown their Edamame cluster, they can persist all their historical load test data beyond the life of their AWS EKS Cluster by executing `edamame archive --all`. This command uploads data associated with each individual test as compressed file objects with the storage class Standard Infrequent Access into an AWS S3 Bucket. If a user wants to archive only the data associated with one historical test, then they can execute `edamame archive --name testName` and replace testName with the name of the test that they would like to archive. The files are archived as objects with Standard Infrequent Access, because this tier provides quick retrieval access and cheap storage relative to some of the other AWS storage class categories. Edamame currently doesn't offer the flexibility to change the storage class of these file uploads via the CLI. However, if a user plans to have this archived data in cold storage for a long time and wants a cheaper storage class option, then they can use Amazon S3 Lifecycle to update the storage class to one of the Glacier categories.
 
+Example:
+`edamame archive --name "100K VUs"`
+
+Terminal Output:
+
+```
+[04:08:56:294] ℹ Starting archive process...
+[04:08:56:544] ℹ Creating edamame-load-tests AWS S3 Bucket located at: aws-region={your region}
+ if it doesn't exist yet...
+[04:09:01:715] ℹ AWS S3 Bucket is ready for uploads.
+[04:09:03:366] ℹ Successfully archived 100K VUs.
+[04:09:03:366] ✔ Archival process complete. Uploaded 1 load test objects to the AWS S3 Bucket: edamame-load-tests
+```
+
 ### edamame delete-from-archive
 
 If a user decides they no longer need the data associated with all or one of their historical load tests that currently exists as an object in their AWS S3 Bucket, then they can execute `edamame delete-from-archive --all` or `edamame delete-from-archive --name testName` to delete all the load test data stored in AWS S3 or the data associated with one historical load test.
+
+Example:
+`edamame delete-from-archive --name "100K VUs"`
+
+Terminal Output:
+
+```
+[04:17:18:812] ℹ Starting archival deletion process...
+[04:17:21:787] ✔ Successfully deleted 100K VUs from the AWS S3 Bucket: edamame-load-tests
+```
 
 ### edamame teardown
 


### PR DESCRIPTION
Updated cli commands documentation to reflect archive feature that gives users the flexibility to persist historical load test data beyond the life of the cluster should they temporarily take down the cluster & postpone additional load testing to a future date